### PR TITLE
fix: normalize overlong Codex call IDs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1155,9 +1155,39 @@ function hiddenSandboxControlToolNames(options) {
 	const retryTools = recentSandboxRetryToolNames(options.messages);
 	return new Set(options.tools?.filter((tool) => hasSandboxControls(tool.parameters) && !retryTools.has(tool.name)).map((tool) => tool.name) ?? []);
 }
+function createCallIdNormalizer() {
+	const normalizedByOriginal = /* @__PURE__ */ new Map();
+	const originalByNormalized = /* @__PURE__ */ new Map();
+	return (value) => {
+		const original = String(value);
+		const existing = normalizedByOriginal.get(original);
+		if (existing !== void 0) return existing;
+		const claim = (candidate) => {
+			const owner = originalByNormalized.get(candidate);
+			if (owner !== void 0 && owner !== original) return false;
+			normalizedByOriginal.set(original, candidate);
+			originalByNormalized.set(candidate, original);
+			return true;
+		};
+		if (original.length <= 64 && claim(original)) return original;
+		for (let attempt = 0;; attempt++) {
+			const material = attempt === 0 ? original : `${original}\0${attempt}`;
+			const candidate = `dsh_${createHash("sha256").update(material).digest("hex").slice(0, 60)}`;
+			if (claim(candidate)) return candidate;
+		}
+	};
+}
+function normalizeReplayCallIds(items, normalizeCallId) {
+	if (items === null) return null;
+	return items.map((item) => typeof item.call_id === "string" ? {
+		...item,
+		call_id: normalizeCallId(item.call_id)
+	} : item);
+}
 async function buildResponsesPayload(options, attachments, localRawImages = {}) {
 	const sandboxRetryTools = recentSandboxRetryToolNames(options.messages);
 	const resolveLocalRawImages = supportsImageInput(options);
+	const normalizeCallId = createCallIdNormalizer();
 	const instructionParts = [
 		options.system?.trim(),
 		...options.messages.filter((message) => message.role === "system").map((message) => blocksToText(message.content).trim()),
@@ -1174,7 +1204,7 @@ async function buildResponsesPayload(options, attachments, localRawImages = {}) 
 	};
 	for (const message of options.messages) {
 		if (message.role === "system") continue;
-		const replayItems = replayOutputItems(message);
+		const replayItems = normalizeReplayCallIds(replayOutputItems(message), normalizeCallId);
 		if (message.role === "assistant" && replayItems !== null) {
 			input.push(...replayItems);
 			for (const item of replayItems) if (item.type === "function_call" && typeof item.call_id === "string") knownToolCalls.set(item.call_id, typeof item.name === "string" ? item.name : void 0);
@@ -1185,12 +1215,13 @@ async function buildResponsesPayload(options, attachments, localRawImages = {}) 
 					content
 				});
 			}
-			appendMissingToolCalls(input, knownToolCalls, message);
+			appendMissingToolCalls(input, knownToolCalls, message, normalizeCallId);
 			continue;
 		}
 		const toolResult = message.content.find((block) => block.type === "tool-result");
 		if (toolResult?.type === "tool-result") {
-			const callId = String(toolResult.toolCallId);
+			const originalCallId = String(toolResult.toolCallId);
+			const callId = normalizeCallId(originalCallId);
 			const rawOutput = blocksToText(toolResult.content);
 			if (knownToolCalls.has(callId)) {
 				const output = toolResult.isError && knownToolCalls.get(callId) === "run_code" ? runCodeErrorOutput(rawOutput) : rawOutput;
@@ -1203,7 +1234,7 @@ async function buildResponsesPayload(options, attachments, localRawImages = {}) 
 				role: "user",
 				content: [{
 					type: "input_text",
-					text: `Tool result for unavailable call ${callId}${toolResult.isError ? " (error)" : ""}:\n${rawOutput}`
+					text: `Tool result for unavailable call ${originalCallId}${toolResult.isError ? " (error)" : ""}:\n${rawOutput}`
 				}]
 			});
 			continue;
@@ -1213,7 +1244,7 @@ async function buildResponsesPayload(options, attachments, localRawImages = {}) 
 			role: message.role,
 			content
 		});
-		if (message.role === "assistant") appendMissingToolCalls(input, knownToolCalls, message);
+		if (message.role === "assistant") appendMissingToolCalls(input, knownToolCalls, message, normalizeCallId);
 	}
 	const payload = {
 		model: options.model,
@@ -1343,10 +1374,10 @@ function recentSandboxRetryToolNames(messages) {
 function isSandboxDenial(output) {
 	return /\[sandbox:\s*file access denied\b/i.test(output) || /\bsandbox\b.*\b(?:access denied|denied access|EPERM)\b/i.test(output);
 }
-function appendMissingToolCalls(input, knownToolCalls, message) {
+function appendMissingToolCalls(input, knownToolCalls, message, normalizeCallId) {
 	for (const block of message.content) {
 		if (block.type !== "tool-call") continue;
-		const callId = String(block.id);
+		const callId = normalizeCallId(block.id);
 		if (knownToolCalls.has(callId)) continue;
 		input.push({
 			type: "function_call",

--- a/src/host/responses-mapper.ts
+++ b/src/host/responses-mapper.ts
@@ -1,5 +1,6 @@
 import type { AttachmentStore, ImageAttachmentRef, ImageMediaType } from '@deepseek-ai/dsh-attachment'
 import type { ContentBlock, GenerateOptions, Message } from '@deepseek-ai/dsh-llm'
+import { createHash } from 'node:crypto'
 import { codexModelSupportsImageInput, codexModelSupportsReasoningSummary } from '../shared/model-catalog.ts'
 
 export interface ResponsesPayload extends Record<string, unknown> {
@@ -29,6 +30,42 @@ export function hiddenSandboxControlToolNames(options: GenerateOptions): Set<str
     .map((tool) => tool.name) ?? [])
 }
 
+function createCallIdNormalizer(): (value: unknown) => string {
+  const normalizedByOriginal = new Map<string, string>()
+  const originalByNormalized = new Map<string, string>()
+
+  return (value) => {
+    const original = String(value)
+    const existing = normalizedByOriginal.get(original)
+    if (existing !== undefined) return existing
+
+    const claim = (candidate: string): boolean => {
+      const owner = originalByNormalized.get(candidate)
+      if (owner !== undefined && owner !== original) return false
+      normalizedByOriginal.set(original, candidate)
+      originalByNormalized.set(candidate, original)
+      return true
+    }
+
+    if (original.length <= 64 && claim(original)) return original
+    for (let attempt = 0; ; attempt++) {
+      const material = attempt === 0 ? original : `${original}\0${attempt}`
+      const candidate = `dsh_${createHash('sha256').update(material).digest('hex').slice(0, 60)}`
+      if (claim(candidate)) return candidate
+    }
+  }
+}
+
+function normalizeReplayCallIds(
+  items: Array<Record<string, unknown>> | null,
+  normalizeCallId: (value: unknown) => string,
+): Array<Record<string, unknown>> | null {
+  if (items === null) return null
+  return items.map((item) => typeof item.call_id === 'string'
+    ? { ...item, call_id: normalizeCallId(item.call_id) }
+    : item)
+}
+
 export async function buildResponsesPayload(
   options: GenerateOptions,
   attachments: Pick<AttachmentStore, 'readImage'> & Partial<Pick<AttachmentStore, 'imageLimits'>>,
@@ -36,6 +73,7 @@ export async function buildResponsesPayload(
 ): Promise<ResponsesPayload> {
   const sandboxRetryTools = recentSandboxRetryToolNames(options.messages)
   const resolveLocalRawImages = supportsImageInput(options)
+  const normalizeCallId = createCallIdNormalizer()
   const instructionParts = [
     options.system?.trim(),
     ...options.messages
@@ -51,7 +89,7 @@ export async function buildResponsesPayload(
   const localImageStats: LocalRawImageStats = { attempted: 0, resolved: 0, failed: 0 }
   for (const message of options.messages) {
     if (message.role === 'system') continue
-    const replayItems = replayOutputItems(message)
+    const replayItems = normalizeReplayCallIds(replayOutputItems(message), normalizeCallId)
     if (message.role === 'assistant' && replayItems !== null) {
       input.push(...replayItems)
       for (const item of replayItems) {
@@ -63,12 +101,13 @@ export async function buildResponsesPayload(
         const content = await mapContent(message, attachments, options.signal, localRawImages, localImageStats, resolveLocalRawImages)
         if (content.length > 0) input.push({ role: message.role, content })
       }
-      appendMissingToolCalls(input, knownToolCalls, message)
+      appendMissingToolCalls(input, knownToolCalls, message, normalizeCallId)
       continue
     }
     const toolResult = message.content.find((block) => block.type === 'tool-result')
     if (toolResult?.type === 'tool-result') {
-      const callId = String(toolResult.toolCallId)
+      const originalCallId = String(toolResult.toolCallId)
+      const callId = normalizeCallId(originalCallId)
       const rawOutput = blocksToText(toolResult.content)
       if (knownToolCalls.has(callId)) {
         const output = toolResult.isError && knownToolCalls.get(callId) === 'run_code'
@@ -83,7 +122,7 @@ export async function buildResponsesPayload(
           role: 'user',
           content: [{
             type: 'input_text',
-            text: `Tool result for unavailable call ${callId}${toolResult.isError ? ' (error)' : ''}:\n${rawOutput}`,
+            text: `Tool result for unavailable call ${originalCallId}${toolResult.isError ? ' (error)' : ''}:\n${rawOutput}`,
           }],
         })
       }
@@ -92,7 +131,7 @@ export async function buildResponsesPayload(
     const content = await mapContent(message, attachments, options.signal, localRawImages, localImageStats, resolveLocalRawImages)
     if (content.length > 0) input.push({ role: message.role, content })
     if (message.role === 'assistant') {
-      appendMissingToolCalls(input, knownToolCalls, message)
+      appendMissingToolCalls(input, knownToolCalls, message, normalizeCallId)
     }
   }
 
@@ -291,10 +330,11 @@ function appendMissingToolCalls(
   input: Array<Record<string, unknown>>,
   knownToolCalls: Map<string, string | undefined>,
   message: Message,
+  normalizeCallId: (value: unknown) => string,
 ): void {
   for (const block of message.content) {
     if (block.type !== 'tool-call') continue
-    const callId = String(block.id)
+    const callId = normalizeCallId(block.id)
     if (knownToolCalls.has(callId)) continue
     input.push({
       type: 'function_call',

--- a/test/responses-mapper.test.ts
+++ b/test/responses-mapper.test.ts
@@ -58,6 +58,68 @@ describe('Responses payload mapping', () => {
     ])
   })
 
+  it('normalizes overlong replayed call ids and preserves matching outputs without collisions', async () => {
+    const sharedPrefix = 'call_' + 'a'.repeat(77)
+    const longCallIds = [`${sharedPrefix}x`, `${sharedPrefix}y`]
+    const messages = longCallIds.flatMap((callId, index) => [
+      {
+        id: `assistant-${index}`, role: 'assistant',
+        source: {
+          kind: 'model', provider: 'codex-chatgpt', model: 'gpt-5.6-sol',
+          replayState: {
+            response: {
+              outputItems: [{ type: 'function_call', call_id: callId, name: 'read_file', arguments: '{}' }],
+            },
+          },
+        },
+        content: [{ type: 'tool-call', id: callId, name: 'read_file', arguments: '{}' }],
+      },
+      {
+        id: `result-${index}`, role: 'user', source: { kind: 'tool', callId },
+        content: [{ type: 'tool-result', toolCallId: callId, content: [{ type: 'text', text: `result-${index}` }] }],
+      },
+    ])
+    const options = {
+      provider: 'codex-chatgpt', model: 'gpt-5.6-sol', messages,
+    } as unknown as GenerateOptions
+
+    const payload = await buildResponsesPayload(options, unusedAttachments())
+    const calls = payload.input.filter((item) => item.type === 'function_call')
+    const outputs = payload.input.filter((item) => item.type === 'function_call_output')
+    const normalizedIds = calls.map((item) => String(item.call_id))
+
+    expect(normalizedIds).toHaveLength(2)
+    expect(new Set(normalizedIds).size).toBe(2)
+    expect(normalizedIds.every((callId) => callId.length <= 64)).toBe(true)
+    expect(normalizedIds.every((callId) => /^dsh_[a-f0-9]{60}$/.test(callId))).toBe(true)
+    expect(outputs.map((item) => item.call_id)).toEqual(normalizedIds)
+  })
+
+  it('normalizes an overlong tool call restored from empty replay state', async () => {
+    const longCallId = 'call_' + 'z'.repeat(78)
+    const options = {
+      provider: 'codex-chatgpt', model: 'gpt-5.6-sol', messages: [
+        {
+          id: 'm1', role: 'assistant',
+          source: { kind: 'model', provider: 'codex-chatgpt', model: 'gpt-5.6-sol', replayState: { outputItems: [] } },
+          content: [{ type: 'tool-call', id: longCallId, name: 'shell', arguments: '{"command":"pwd"}' }],
+        },
+        {
+          id: 'm2', role: 'user', source: { kind: 'tool', callId: longCallId },
+          content: [{ type: 'tool-result', toolCallId: longCallId, content: [{ type: 'text', text: '/workspace' }] }],
+        },
+      ],
+    } as unknown as GenerateOptions
+
+    const payload = await buildResponsesPayload(options, unusedAttachments())
+    const call = payload.input.find((item) => item.type === 'function_call')
+    const output = payload.input.find((item) => item.type === 'function_call_output')
+
+    expect(call?.call_id).toMatch(/^dsh_[a-f0-9]{60}$/)
+    expect(String(call?.call_id)).toHaveLength(64)
+    expect(output?.call_id).toBe(call?.call_id)
+  })
+
   it('warns the model when a user message has only a local raw image markdown link', async () => {
     const text = '请看这张图\n![图片](/describe-image/raw/sha256:fb8625f2d563722a61b6bc791d665d758bd083bbd0b96f7a4693a3d2a1159eda)'
     const options = {


### PR DESCRIPTION
## Problem

Resuming or forking a DSH session created by another provider can replay a `function_call.call_id` longer than the Codex Responses API limit of 64 characters. The subscription provider forwards that ID unchanged, causing every subsequent request in the inherited session to fail with HTTP 400.

Closes #1.

## Changes

- normalize overlong call IDs to deterministic 64-character SHA-256-based IDs while constructing a Responses payload
- reuse the same mapping for replayed calls, restored missing calls, and matching `function_call_output` items
- preserve existing IDs that already fit the 64-character limit
- guard against normalized-ID collisions within one payload
- regenerate the published host bundle

## Verification

- `npm test -- --run test/responses-mapper.test.ts` — 22 passed
- `npm run typecheck` — passed
- `NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 npm test` — 78 passed, 6 skipped
- `npm run build` — passed

No UI changes; screenshots are not applicable.