### PR TITLE
fix: put the daily endpoint first and request thought summaries so reasoning, quota, and streaming all work

### DIFF
--- a/src/host/antigravity/mapper.ts
+++ b/src/host/antigravity/mapper.ts
@@ -301,11 +301,18 @@ export function buildRequest(
 
   const generationConfig: Record<string, unknown> = {}
   if (options.temperature !== undefined) generationConfig.temperature = options.temperature
+  // Gemini 只在 thinkingConfig.includeThoughts 为 true 时才返回 thought 部分，否则模型照常思考
+  // （usageMetadata.thoughtsTokenCount 照常计入）但流里没有可渲染的思维链。tiered 运行时的思考
+  // 档位由 effort 决定；其余带档位后缀的 gemini 运行时档位已在模型名里，只需请求返回思考内容。
+  // Claude 运行时依赖 anthropic-beta interleaved-thinking 头，不发送 thinkingConfig。
   if (runtimeModel === 'gemini-3.8-flash-tiered' || runtimeModel === 'gemini-3.7-flash-tiered') {
     const selected = effort || 'off'
     generationConfig.thinkingConfig = {
       thinkingLevel: selected === 'high' || selected === 'xhigh' ? 'HIGH' : selected === 'medium' ? 'MEDIUM' : 'LOW',
+      includeThoughts: true,
     }
+  } else if (/^gemini-.+(?:-tiered|-(?:extra-)?low|-medium|-high|-xhigh)$/.test(runtimeModel)) {
+    generationConfig.thinkingConfig = { includeThoughts: true }
   }
 
   const maxAllowed = getMaxOutputTokens(model.id, runtimeModel)

--- a/src/host/antigravity/types.ts
+++ b/src/host/antigravity/types.ts
@@ -9,9 +9,12 @@ export const MODEL_CACHE_TTL_MS = 30 * 60 * 1000
 export const OAUTH_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000
 
 export const DEFAULT_ENDPOINT = 'https://cloudcode-pa.googleapis.com'
+// 官方 Antigravity 客户端的调用顺序是 daily 在前、prod 兜底。生产端点对流式生成间歇性返回
+// 429，且不回传 thought 部分（思维链）、配额摘要也是冻结快照；daily 端点三类数据都正常。
+export const DAILY_ENDPOINT = 'https://daily-cloudcode-pa.googleapis.com'
 export const ENDPOINT_FALLBACKS = [
+  DAILY_ENDPOINT,
   DEFAULT_ENDPOINT,
-  'https://daily-cloudcode-pa.sandbox.googleapis.com',
 ]
 
 export const REDIRECT_PATH = '/oauth-callback'

--- a/test/antigravity-mapper.test.ts
+++ b/test/antigravity-mapper.test.ts
@@ -64,6 +64,32 @@ describe('Antigravity Mapper', () => {
     expect(tools[0].functionDeclarations[0].name).toBe('get_weather')
   })
 
+  it('requests thought summaries for thinking gemini runtimes only', () => {
+    const options = {
+      provider: 'antigravity',
+      model: 'gemini-3.8-flash',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello AI' }] }],
+    } as unknown as GenerateOptions
+
+    // tiered 运行时：思考档位来自 effort，同时必须请求返回思考内容
+    const tiered = buildRequest(options, testModel, 'p', 'gemini-3.7-flash-tiered', 'high')
+    expect((tiered.request as Record<string, unknown>).generationConfig).toMatchObject({
+      thinkingConfig: { thinkingLevel: 'HIGH', includeThoughts: true },
+    })
+
+    // 档位后缀运行时：档位在模型名里，只补 includeThoughts
+    const suffixed = buildRequest(options, testModel, 'p', 'gemini-3.6-flash-high', 'medium')
+    expect((suffixed.request as Record<string, unknown>).generationConfig).toMatchObject({
+      thinkingConfig: { includeThoughts: true },
+    })
+
+    // 非思考运行时不携带 thinkingConfig
+    for (const runtime of ['gemini-3-flash', 'gemini-2.5-pro', 'claude-sonnet-4-6', 'gpt-oss-120b-medium']) {
+      const request = buildRequest(options, testModel, 'p', runtime, 'high')
+      expect((request.request as Record<string, unknown>).generationConfig).not.toHaveProperty('thinkingConfig')
+    }
+  })
+
   it('parses SSE text, thinking reasoning, and tool calls', () => {
     const state = createStreamState()
 

--- a/test/antigravity-quota.test.ts
+++ b/test/antigravity-quota.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { parseCatalogModels, parseQuotaSummary } from '../src/host/antigravity/client.ts'
+import { DEFAULT_ENDPOINT, DAILY_ENDPOINT, ENDPOINT_FALLBACKS } from '../src/host/antigravity/types.ts'
 
 describe('Antigravity Quota & Catalog Parser', () => {
   it('parses quota groups and buckets with remaining fraction clamping', () => {
@@ -72,5 +73,13 @@ describe('Antigravity Quota & Catalog Parser', () => {
     expect(catalog).toHaveLength(2)
     expect(catalog.map((m) => m.id)).toEqual(['gemini-3.7-flash', 'claude-opus-4-6'])
     expect(catalog[0].name).toBe('Gemini 3.7 Flash')
+  })
+
+  it('queries the daily endpoint first, matching the official Antigravity call chain', () => {
+    // 生产端点对流式生成间歇性 429、不回传 thought 部分、配额摘要是冻结快照；
+    // daily 端点三类数据都正常，官方客户端即以 daily 为首选。
+    expect(ENDPOINT_FALLBACKS[0]).toBe(DAILY_ENDPOINT)
+    expect(ENDPOINT_FALLBACKS).toContain(DEFAULT_ENDPOINT)
+    expect(ENDPOINT_FALLBACKS.indexOf(DAILY_ENDPOINT)).toBeLessThan(ENDPOINT_FALLBACKS.indexOf(DEFAULT_ENDPOINT))
   })
 })


### PR DESCRIPTION
## 问题

使用本插件时观察到三个症状，追查后发现都指向同一处：插件把 **生产端点** `cloudcode-pa.googleapis.com` 当作首选，而官方 Antigravity 客户端的调用链是 **daily 端点优先**（`daily-cloudcode-pa.googleapis.com`），prod 仅作兜底。

| 症状 | 生产端点（插件原首选） | daily 端点（官方首选） |
|---|---|---|
| 流式响应中的 thought parts（思维链） | 从不返回，即使请求带 `includeThoughts: true` | 正常返回 |
| 流式生成 | 间歇性 429 RESOURCE_EXHAUSTED | 正常（实测 4 秒完成整轮） |
| `retrieveUserQuotaSummary` 配额摘要 | 冻结快照，所有桶 `remainingFraction` 恒为 1 | 真实用量 |

另外 `buildRequest` 从未发送 `thinkingConfig.includeThoughts: true`：Gemini 不显式请求时模型照常思考（`usageMetadata.thoughtsTokenCount` 照常计费），但流里没有可渲染的思维链。

## 修复

1. `ENDPOINT_FALLBACKS` 调整为 daily 在前、prod 兜底，与官方调用链一致。
2. `buildRequest` 的 `thinkingConfig` 补上 `includeThoughts: true`：tiered 运行时的思考档位仍由 effort 决定；其余带档位后缀的 gemini 运行时档位已在模型名里，只补 `includeThoughts`。Claude 运行时保持不动（走 `anthropic-beta` interleaved-thinking 头）。

## 实测（免费档账号 + `gemini-3.8-flash`）

- 修复前：对话无任何 reasoning 事件；设置页配额恒为 100%；生成请求频繁 429。
- 修复后：daily 端点的流里返回 `{"thought": true, "text": "..."}` 与 `thoughtSignature`，DSH 会话日志出现完整 reasoning 块并在 UI 渲染"已思考"内容；配额显示真实余量（周额度 83.0%、5 小时窗口 82.1%）；整轮对话 4 秒完成，无 429。

## 测试

- `test/antigravity-mapper.test.ts`：新增 thinkingConfig 断言（tiered 与档位后缀运行时发送 `includeThoughts`，非思考运行时不发送）。
- `test/antigravity-quota.test.ts`：新增 ENDPOINT_FALLBACKS 顺序断言（daily 在前）。
- `npx vitest run`：121 passed（1 个既有的 `routes.test.ts` hook 超时失败与本次改动无关，在未修改代码上同样失败）。